### PR TITLE
Fix login

### DIFF
--- a/src/main/java/oakbot/util/ChatUtils.java
+++ b/src/main/java/oakbot/util/ChatUtils.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
  * @author Michael Angstadt
  */
 public class ChatUtils {
-	private static final Pattern fkeyRegex = Pattern.compile("value=\"([0-9a-f]{32})\"");
+	private static final Pattern fkeyRegex = Pattern.compile("name=\"fkey\"\\s+(?>type=\"hidden\"\\s+)?value=\"([^\"]+)\"");
 
 	/**
 	 * Parses the "fkey" field out of an HTML page.


### PR DESCRIPTION
## Why this exists

https://chat.stackoverflow.com/transcript/message/41645643#41645643

## What happened

The fkey on the login page is 64 chars, but the one in chat is 32 chars. Meaning defining the length is a pain, since it isn't universal. The regex I added here is one I use in my project too, which simply does [something stupid](https://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454) by parsing more of the HTML. It doesn't define a length, but it's more or less guaranteed to find the right tag as the pattern is the same in chat and across the SE network (meaning it's the same on SO, SE and MSE, both in chat and login). 

Anyways, removing the length definition and increasing the amount of data necessary to match still leads to a single match, and this time it doesn't require the fkey to be a specific length. Meaning it can get the 32 char one from chat and the 64 char one from login. And it's mostly future-proof too.

And I did test this before I made the PR to make sure it works: and it does. At least for the time being.